### PR TITLE
[EXP-2127] Integrate glean_parser code generation with Nimbus build.rs

### DIFF
--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -80,6 +80,9 @@ nimbus_events:
       enrollment_id:
         type: string
         description: A unique identifier generated at enrollment time
+      reason:
+        type: string
+        description: The reason for the disqualification
     bugs:
       - https://jira.mozilla.com/browse/SDK-126
     data_reviews:

--- a/components/nimbus/src/glean_metrics.rs
+++ b/components/nimbus/src/glean_metrics.rs
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::env;
+
+// This includes the generated Glean Rust bindings, which get exposed
+// via the `mod glean_metrics` include in lib.rs
+include!(concat!(env!("OUT_DIR"), "/glean_metrics.rs"));

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -34,6 +34,9 @@ use evaluator::is_experiment_available;
 // Exposed for Example only
 pub use evaluator::TargetingAttributes;
 
+// Expose generated Glean Rust metrics
+mod glean_metrics;
+
 // We only use this in a test, and with --no-default-features, we don't use it
 // at all
 #[allow(unused_imports)]


### PR DESCRIPTION
Add metrics.yaml processing by glean_parser via a python script located in tools/bootstrap_glean_rust.py### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
